### PR TITLE
Relax the rule for detecting whether firefox-addon was invoked as a script

### DIFF
--- a/library/firefox_addon
+++ b/library/firefox_addon
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 script() {
-  [[ ${0##*/} = firefox_addon ]]
+  [[ ${0##*/} =~ ^(AnsiballZ_)?firefox_addon$ ]]
 }
 
 fail() {


### PR DESCRIPTION
### Problem

It looks like introducing Ansiballz in Ansible 2.1+ caused the script to be invoked differently, ie
with an 'AnsiballZ_' prefix, which makes the module exit with failure and with no debugging info. 

### Solution
Relax the condition to remove the false negative.

More about introducing AnsiballZ: https://docs.ansible.com/ansible/2.3/dev_guide/developing_program_flow_modules.html#ansiballz