### PR TITLE
Match firefox addon with Ansible prefixes

### DIFF
--- a/library/firefox_addon
+++ b/library/firefox_addon
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 script() {
-  [[ ${0##*/} = firefox_addon ]]
+  [[ ${0##*/} =~ .*firefox_addon ]]
 }
 
 fail() {


### PR DESCRIPTION
Currently the module fails on OSX since the script is prefixed with AnsiballZ